### PR TITLE
feat: handle ENOTFOUND

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ function shouldRetry (err, res, allowedStatuses) {
     'ECONNRESET',
     'ETIMEDOUT',
     'EADDRINFO',
-    'ESOCKETTIMEDOUT'
+    'ESOCKETTIMEDOUT',
+    'ENOTFOUND'
   ]
 
   if (err && err.code && ~ERROR_CODES.indexOf(err.code)) {


### PR DESCRIPTION
In some cases you may get this error even if the resource is actually accessible, I'm not sure why, but it happens. Retrying doesn't hurt