### PR TITLE
Upgrading superagent to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "src/index",
   "dependencies": {},
   "peerDependencies": {
-    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0"
+    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
   },
   "devDependencies": {
     "express": "^4.17.1",
@@ -29,7 +29,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.1",
     "should": "^13.2.3",
-    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0"
+    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
   },
   "scripts": {
     "test": "node_modules/.bin/nyc --reporter=lcov mocha --color --recursive --timeout=20000 tests/"


### PR DESCRIPTION
About 5 months ago superagent launched the 7.x version of superagent, so i just upgraded him on `package.json` to not get any warning messages about peerDependencies using latest versions of superagent.