### PR TITLE
Allow superagent v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "src/index",
   "dependencies": {},
   "peerDependencies": {
-    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "devDependencies": {
     "express": "^4.17.1",
@@ -29,7 +29,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.1",
     "should": "^13.2.3",
-    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
+    "superagent": "^3.5.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "scripts": {
     "test": "node_modules/.bin/nyc --reporter=lcov mocha --color --recursive --timeout=20000 tests/"


### PR DESCRIPTION
Released superagent v8.0.0 at Jun 24, 2022.
Allowed so that the warning is not displayed.
