### PR TITLE
Still allow providing a callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NODE_CONTAINER?=node:16-alpine
 
-NODE_RUN=docker run --net=host -v ~/.paloalto/openssl.cnf:/etc/openssl.cnf -v ~/.paloalto/paloalto_roots.pem:/etc/ssl/certs/paloalto_roots.pem --env-file ~/.paloalto/certs.env --rm -v "$(PWD):/workdir" -w "/workdir" --rm $(NODE_CONTAINER)
+NODE_RUN=docker run --rm -v "$(PWD):/workdir" -w "/workdir" --rm $(NODE_CONTAINER)
 
 install:
 	$(NODE_RUN) yarn install

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NODE_CONTAINER?=node:16-alpine
 
-NODE_RUN=docker run --rm -v "$(PWD):/workdir" -w "/workdir" --rm $(NODE_CONTAINER)
+NODE_RUN=docker run --net=host -v ~/.paloalto/openssl.cnf:/etc/openssl.cnf -v ~/.paloalto/paloalto_roots.pem:/etc/ssl/certs/paloalto_roots.pem --env-file ~/.paloalto/certs.env --rm -v "$(PWD):/workdir" -w "/workdir" --rm $(NODE_CONTAINER)
 
 install:
 	$(NODE_RUN) yarn install

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ superagent
   .retry(5, [1000, 3000], [401, 404]) // retry five times before responding, first wait 1 second, and then wait 3 seconds between all other failures, do not retry when response is success, or 401 or 404
   .end(onresponse);
 
+superagent
+  .get('https://segment.io')
+  .retry(5, [1000, 3000], [], (res, err) => {
+    if(res.status === 400 && res.text.includes('banana')) {
+      return true
+    } 
+    return false;
+  }) // retry five times before responding, first wait 1 second, and then wait 3 seconds between all other failures, retry if code is 400 and body contains banana
+  .end(onresponse);
+
+
 function onresponse (err, res) {
   console.log(res.status, res.headers);
   console.log(res.body);

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,10 @@ module.exports = function (superagent) {
  * @param {Response} res
  * @param allowedStatuses
  */
-function shouldRetry(err, res, allowedStatuses) {
+function shouldRetry(err, res, allowedStatuses, callback) {
+  if (callback) {
+    return callback(err, res);
+  }
   const ERROR_CODES = [
     "ECONNRESET",
     "ETIMEDOUT",
@@ -71,7 +74,7 @@ function callback(err, res) {
   if (
     this._maxRetries &&
     this._retries++ < this._maxRetries &&
-    shouldRetry(err, res, this._allowedStatuses)
+    shouldRetry(err, res, this._allowedStatuses, this._retryCallback)
   ) {
     let delay;
     if (!this._retries) {
@@ -107,7 +110,7 @@ function callback(err, res) {
  * @param {Number[]} allowedStatuses
  * @return {retry}
  */
-function retry(retries, delays, allowedStatuses) {
+function retry(retries, delays, allowedStatuses, callback) {
   if (arguments.length === 0 || retries === true) {
     retries = 1;
   }
@@ -138,6 +141,6 @@ function retry(retries, delays, allowedStatuses) {
   this._retries = 0;
   this._retryDelays = delays || [0];
   this._allowedStatuses = allowedStatuses || [];
-
+  this._retryCallback = callback;
   return this;
 }


### PR DESCRIPTION
@luispabon just adding the ability here to still provide a callback while allowing for delays.

Our use case here is we need to inspect the response body to make the determination about whether to retry or not we can't just rely on the response code.  With vanilla superagent we can do this but then it just fires all the retries as fast as possible.  With this change we will be able to use the delaying functionality of superagent-retry-delay while not losing the ability to deep dive into response/error to make the retry decision.