### PR TITLE
Mirror superagent behaviour in call back for creating errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const http = require('http');
+const http = require("http");
 /**
  * Add to the request prototype.
  */
@@ -97,7 +97,7 @@ function callback(err, res) {
   if (!err) {
     try {
       if (!this._isResponseOK(res)) {
-        let message = 'Unsuccessful HTTP response';
+        let message = "Unsuccessful HTTP response";
         if (res) {
           message = http.STATUS_CODES[res.status] || message;
         }
@@ -116,11 +116,10 @@ function callback(err, res) {
 
   err.response = res;
 
-
   if (err) {
     if (this._maxRetries) err.retries = this._retries - 1;
-    if (err && this.listeners('error').length > 0) {
-      this.emit('error', err);
+    if (err && this.listeners("error").length > 0) {
+      this.emit("error", err);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const http = require('http');
 /**
  * Add to the request prototype.
  */
@@ -105,8 +106,8 @@ function callback(err, res) {
         err.status = res ? res.status : undefined;
       }
     } catch (e) {
-      error = e;
-      error.status = error.status || (res ? res.status : undefined);
+      err = e;
+      err.status = err.status || (res ? res.status : undefined);
     }
   }
   if (!err) {

--- a/src/index.js
+++ b/src/index.js
@@ -90,13 +90,37 @@ function callback(err, res) {
       return req._retry();
     }, delay);
   }
-
   const fn = this._callback;
   this.clearTimeout();
 
+  if (!err) {
+    try {
+      if (!this._isResponseOK(res)) {
+        let message = 'Unsuccessful HTTP response';
+        if (res) {
+          message = http.STATUS_CODES[res.status] || message;
+        }
+
+        err = new Error(message);
+        err.status = res ? res.status : undefined;
+      }
+    } catch (e) {
+      error = e;
+      error.status = error.status || (res ? res.status : undefined);
+    }
+  }
+  if (!err) {
+    return fn(null, res);
+  }
+
+  err.response = res;
+
+
   if (err) {
     if (this._maxRetries) err.retries = this._retries - 1;
-    this.emit("error", err);
+    if (err && this.listeners('error').length > 0) {
+      this.emit('error', err);
+    }
   }
 
   fn(err, res);

--- a/tests/test.js
+++ b/tests/test.js
@@ -11,6 +11,61 @@ const http = require("http");
 http.globalAgent.maxSockets = 2000;
 
 describe("superagent-retry-delay", function () {
+  describe("error synthesizing", function () {
+    let requests = 0;
+    const port = 10410;
+    const app = express();
+    let server;
+    before(function (done) {
+      app.get("/", function (req, res, next) {
+        requests++;
+        res.sendStatus(404);
+      });
+
+      server = app.listen(port, done);
+    });
+
+    afterEach(function () {
+      requests = 0;
+    });
+
+    it("emits error when listener is attached", function (done) {
+      let received = false;
+      agent
+        .get("http://localhost:" + port)
+        .on('error', (err) => {
+          received = true;
+        })
+        .end(function (err, res) {
+          res.text.should.eql("Not Found");          
+          err.response.status.should.eql(404);
+          err.status.should.eql(404);
+          err.message.should.eql("Not Found");
+          requests.should.eql(1);
+          received.should.eql(true);
+          done();
+        });
+    });
+
+    it("catches errors in the _isResponseOK and returns", function (done) {
+      const oldHandler = agent.Request.prototype._isResponseOK;
+      agent.Request.prototype._isResponseOK = (res) => { throw new Error("_isResponseOK callback error");};
+      agent
+        .get("http://localhost:" + port)
+        .end(function (err, res) {
+          res.text.should.eql("Not Found");
+          err.response.status.should.eql(404);
+          err.message.should.eql("_isResponseOK callback error");
+          requests.should.eql(1);
+          agent.Request.prototype._isResponseOK = oldHandler;
+          done();
+        });
+    });
+
+    after(function (done) {
+      server.close(done);
+    });
+  });
   describe("not-errors", function () {
     let requests = 0;
     const port = 10410;

--- a/tests/test.js
+++ b/tests/test.js
@@ -33,11 +33,11 @@ describe("superagent-retry-delay", function () {
       let received = false;
       agent
         .get("http://localhost:" + port)
-        .on('error', (err) => {
+        .on("error", (err) => {
           received = true;
         })
         .end(function (err, res) {
-          res.text.should.eql("Not Found");          
+          res.text.should.eql("Not Found");
           err.response.status.should.eql(404);
           err.status.should.eql(404);
           err.message.should.eql("Not Found");
@@ -49,17 +49,17 @@ describe("superagent-retry-delay", function () {
 
     it("catches errors in the _isResponseOK and returns", function (done) {
       const oldHandler = agent.Request.prototype._isResponseOK;
-      agent.Request.prototype._isResponseOK = (res) => { throw new Error("_isResponseOK callback error");};
-      agent
-        .get("http://localhost:" + port)
-        .end(function (err, res) {
-          res.text.should.eql("Not Found");
-          err.response.status.should.eql(404);
-          err.message.should.eql("_isResponseOK callback error");
-          requests.should.eql(1);
-          agent.Request.prototype._isResponseOK = oldHandler;
-          done();
-        });
+      agent.Request.prototype._isResponseOK = (res) => {
+        throw new Error("_isResponseOK callback error");
+      };
+      agent.get("http://localhost:" + port).end(function (err, res) {
+        res.text.should.eql("Not Found");
+        err.response.status.should.eql(404);
+        err.message.should.eql("_isResponseOK callback error");
+        requests.should.eql(1);
+        agent.Request.prototype._isResponseOK = oldHandler;
+        done();
+      });
     });
 
     after(function (done) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -89,7 +89,9 @@ describe("superagent-retry-delay", function () {
         .end(function (err, res) {
           res.status.should.eql(404);
           requests.should.eql(3);
-          done(err);
+          err.response.status.should.eql(404);
+          err.message.should.eql("Not Found");
+          done();
         });
     });
 
@@ -100,7 +102,9 @@ describe("superagent-retry-delay", function () {
         .end(function (err, res) {
           res.status.should.eql(404);
           requests.should.eql(3);
-          done(err);
+          err.response.status.should.eql(404);
+          err.message.should.eql("Not Found");
+          done();
         });
     });
 
@@ -428,7 +432,8 @@ describe("superagent-retry-delay", function () {
         .end(function (err, res) {
           res.text.should.eql("Misdirected Request");
           requests.should.eql(2);
-          done(err);
+          err.message.should.eql("Misdirected Request");
+          done();
         });
     });
 


### PR DESCRIPTION
In our use of this delay module we noticed a difference in our end callback behaviour when just including the retry-delay.  This is porting https://github.com/ladjs/superagent/blob/master/src/node/index.js#L893-L908 this section of the core superagent callback into the retry-delay callback to create errors on a non-ok response. to mirror the core superagent behaviour