### PR TITLE
Prep 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NODE_CONTAINER?=node:16-alpine
+NODE_CONTAINER?=node:20-alpine
 
 NODE_RUN=docker run --rm -v "$(PWD):/workdir" -w "/workdir" --rm $(NODE_CONTAINER)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-retry-delay",
-  "version": "2.8.1",
+  "version": "3.0.0",
   "description": "A retrying layer for a superagent request with delay support",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
An issue on our error handling was corrected recently which required a [substantial change](https://github.com/luispabon/superagent-retry-delay/pull/14) to how our errors are emitted. So even though there's no actual functionality besides this fix we need to bump major version as per semver.

