### PR TITLE
Allow delay to be omitted from function params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,9 +132,9 @@ function callback(err, res) {
  * In milliseconds.
  *
  * @param {Number} retries
- * @param {Number[] || Number} delays
- * @param {Number[]} allowedStatuses
- * @param {retryCallback} retryCallback
+ * @param {Number[] || Number || undefined} delays
+ * @param {Number[] || undefined} allowedStatuses
+ * @param {retryCallback || undefined} retryCallback
  * @callback retryCallback
  * @return {retry}
  */

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,10 @@ function retry(retries, delays, allowedStatuses, retryCallback) {
     delays = [delays];
   }
 
+  if (!delays) {
+    delays = [0];
+  }
+
   const numberOfDelays = delays.length;
   const diff = retries - numberOfDelays;
   if (diff !== 0) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -359,6 +359,25 @@ describe("superagent-retry-delay", function () {
         });
     });
 
+    it("should retry on errors - no delay provided", function (done) {
+      agent.get("http://localhost:" + port).end(function (err, res) {
+        res.status.should.eql(404);
+
+        // appease eslint, do nothing with error to allow it to bubble up
+        if (err) {
+        }
+      });
+
+      agent
+        .get("http://localhost:" + port)
+        .retry(5)
+        .end(function (err, res) {
+          res.text.should.eql("hello!");
+          requests.should.eql(5);
+          done(err);
+        });
+    });
+
     after(function (done) {
       server.close(done);
     });


### PR DESCRIPTION
Including this dependency would break calls to retry without a delay provided.

The PR allows delay to be omitted.